### PR TITLE
Continue matching paths on children of 'undefined' routes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,21 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+function extractChildRoutes(route, prefix) {
+  var paths = [];
+  var childRoutes = route.props && route.props.children ? route.props.children : route.childRoutes;
+  if (childRoutes) {
+    if (Array.isArray(childRoutes)) {
+      childRoutes.forEach(function (r) {
+        paths = paths.concat(extractRoute(r, prefix));
+      });
+    } else {
+      paths = paths.concat(extractRoute(childRoutes, prefix));
+    }
+  }
+  return paths;
+}
+
 function extractRoute(route, prefix) {
   var path = route.props && route.props.path ? route.props.path : route.path;
   var paths = [];
@@ -15,24 +30,14 @@ function extractRoute(route, prefix) {
 
       return paths;
     } else {
-      return [];
+      return extractChildRoutes(route, prefix);
     }
   }
   var currentPath = '' + (prefix || '') + path.replace(/\//, '');
 
   if (!/:|\*/.test(currentPath)) {
     paths.push('' + (currentPath.startsWith('/') ? '' : '/') + currentPath);
-
-    var childRoutes = route.props && route.props.children ? route.props.children : route.childRoutes;
-    if (childRoutes) {
-      if (Array.isArray(childRoutes)) {
-        childRoutes.forEach(function (r) {
-          paths = paths.concat(extractRoute(r, currentPath + '/'));
-        });
-      } else {
-        paths = paths.concat(extractRoute(childRoutes, currentPath + '/'));
-      }
-    }
+    paths = paths.concat(extractChildRoutes(route, currentPath + '/'));
   }
   return paths;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,19 @@
+function extractChildRoutes (route, prefix) {
+  let paths = [];
+  const childRoutes = route.props && route.props.children ?
+    route.props.children : route.childRoutes;
+  if (childRoutes) {
+    if (Array.isArray(childRoutes)) {
+      childRoutes.forEach((r) => {
+        paths = paths.concat(extractRoute(r, prefix));
+      });
+    } else {
+      paths = paths.concat(extractRoute(childRoutes, prefix));
+    }
+  }
+  return paths;
+}
+
 function extractRoute (route, prefix) {
   const path = route.props && route.props.path ? route.props.path : route.path;
   let paths = [];
@@ -10,7 +26,7 @@ function extractRoute (route, prefix) {
 
       return paths;
     } else {
-      return [];
+      return extractChildRoutes(route, prefix)
     }
   }
   const currentPath = (
@@ -19,18 +35,7 @@ function extractRoute (route, prefix) {
 
   if (!/:|\*/.test(currentPath)) {
     paths.push(`${currentPath.startsWith('/') ? '' : '/'}${currentPath}`);
-
-    const childRoutes = route.props && route.props.children ?
-      route.props.children : route.childRoutes;
-    if (childRoutes) {
-      if (Array.isArray(childRoutes)) {
-        childRoutes.forEach((r) => {
-          paths = paths.concat(extractRoute(r, `${currentPath}/`));
-        });
-      } else {
-        paths = paths.concat(extractRoute(childRoutes, `${currentPath}/`));
-      }
-    }
+    paths = paths.concat(extractChildRoutes(route, `${currentPath}/`));
   }
   return paths;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -137,3 +137,40 @@ test('ignores no match route', function(t) {
     '/', '/about'
   ].join());
 });
+
+test('loads children of undefined routes', function(t) {
+  t.plan(1);
+
+  let output = reactRouterToArray(
+    <Route>
+      <Route path="/" component={FakeComponent}>
+        <Route>
+          <Route path="about" component={FakeComponent} />
+        </Route>
+      </Route>
+    </Route>
+  );
+
+  t.equal(output.join(), ['/', '/about'].join());
+})
+
+test('loads children of undefined plain routes', function(t) {
+  t.plan(1);
+
+  let output = reactRouterToArray(
+    [
+      {childRoutes: [
+        {
+          path: '/', component: FakeComponent,
+          childRoutes: [
+            {childRoutes: [
+              {path: 'about', component: FakeComponent}
+            ]}
+          ]
+        }
+      ]}
+    ]
+  );
+
+  t.equal(output.join(), ['/', '/about'].join());
+})


### PR DESCRIPTION
In the case that a route’s `path` prop is `undefined`, RR will fall through to matching on the child routes. This adds the same fall-through behavior to the path extraction.

The following example config currently yields no paths, but yields `["/"]` with this PR:
```jsx
<Route component={SomeContainerComponent}>
  <Route path="/" component={SomeNestedComponent} />
</Route>
```