### PR TITLE
move react to peerdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-react": "^6.1.18",
     "tape": "^4.0.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^15.1.0",
     "react-router": "^2.4.1"
   }


### PR DESCRIPTION
Should be peerDependency, so it does not install a fixed version of React, which will conflict with newer versions.