### PR TITLE
fixes bug where the first "/" gets removed from deep paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ function extractRoute(route, prefix) {
       return extractChildRoutes(route, prefix);
     }
   }
-  var currentPath = '' + (prefix || '') + path.replace(/\//, '');
+  var currentPath = ('' + (prefix || '') + path).replace(/\/+/g, '/');
 
   if (!/:|\*/.test(currentPath)) {
     paths.push('' + (currentPath.startsWith('/') ? '' : '/') + currentPath);

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ function extractRoute (route, prefix) {
     }
   }
   const currentPath = (
-    `${prefix || ''}${path.replace(/\//, '')}`
+    `${prefix || ''}${path}`.replace(/\/+/g, '/')
   );
 
   if (!/:|\*/.test(currentPath)) {

--- a/test/index.js
+++ b/test/index.js
@@ -174,3 +174,22 @@ test('loads children of undefined plain routes', function(t) {
 
   t.equal(output.join(), ['/', '/about'].join());
 })
+
+test('loads chidren that have deep paths', function(t) {
+  t.plan(1);
+
+  let output = reactRouterToArray(
+    <Route>
+      <Route path="one">
+        <IndexRoute component={FakeComponent} />
+        <Route path="two/three/four" component={FakeComponent} />
+        <Route path="two/three/five" component={FakeComponent} />
+        <Route path="two/three/six" component={FakeComponent} />
+      </Route>
+    </Route>
+  );
+
+  t.equal(output.join(), [
+    '/one', '/one/two/three/four', '/one/two/three/five', '/one/two/three/six'
+  ].join());
+})


### PR DESCRIPTION
```jsx
<Route>
  <Route path="one">
    <IndexRoute component={FakeComponent} />
    <Route path="two/three/four" component={FakeComponent} />
    <Route path="two/three/five" component={FakeComponent} />
    <Route path="two/three/six" component={FakeComponent} />
  </Route>
</Route>
```

Was getting converted to:

```js
[
  '/one',
  '/one/twothree/four',
  '/one/twothree/five',
  '/one/twothree/six'
]
```